### PR TITLE
Add support for Python 3.3, six >= 1.7 is required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - python: "2.7"
       env: DEPS="numpy=1.9 scipy=0.15 astropy=1.0"
-    - python: "3.3"
-      env: DEPS="numpy=1.7 scipy=0.12 astropy=1.0"
     - python: "3.4"
       env: DEPS="numpy=1.9 scipy=0.15 astropy=1.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
   include:
     - python: "2.7"
       env: DEPS="numpy=1.9 scipy=0.15 astropy=1.0"
+    - python: "3.3"
+      env: DEPS="numpy=1.7 scipy=0.12 astropy=1.0"
     - python: "3.4"
       env: DEPS="numpy=1.9 scipy=0.15 astropy=1.0"
 
@@ -15,7 +17,7 @@ install:
   # OK, this used to *fix* the build, but now it *breaks* the build.
   # If you're reading this, good luck out there. I'm not sure what to tell you.
   - conda update --yes conda
-  - conda create -n testenv --yes $DEPS pip pytest setuptools six pyyaml python=$TRAVIS_PYTHON_VERSION
+  - conda create -n testenv --yes $DEPS pip pytest setuptools six>=1.7 pyyaml python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # for debugging...
   - echo $PATH

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ details.
 Requirements
 ------------
 
-Python 2.7 or 3.4 is required. Numina requires the following 
+Python 2.7 or 3.3 (or greater) is required. Numina requires the following 
 packages installed in order to work properly:
 
  - setuptools (http://pythonhosted.org/setuptools/)

--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,14 @@ details.
 Requirements
 ------------
 
-Python 2.7 is required. Numina requires the following 
+Python 2.7 or 3.4 is required. Numina requires the following 
 packages installed in order to work properly:
 
- - numpy (http://numpy.scipy.org/) 
+ - setuptools (http://pythonhosted.org/setuptools/)
+ - six >= 1.7 (https://pythonhosted.org/six/)
+ - numpy >= 1.6 (http://numpy.scipy.org/) 
  - scipy (http://www.scipy.org)
- - astropy >= 0.4 (http://www.astropy.org/)
+ - astropy >= 1.0 (http://www.astropy.org/)
  - PyYaml (http://pyyaml.org/)
  
 The documentation of the project is generated using Sphinx (http://sphinx.pocoo.org/)
@@ -56,7 +58,7 @@ Development version
 
 The development version can be checked out with:::
 
-    $ hg clone https://guaix.fis.ucm.es/hg/numina
+    $ git clone https://github.com/guaix-ucm/numina.git
 
 And then installed following the standard procedure:::
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ ext2 = Extension('numina.array._ufunc',
                  ],
           include_dirs=[numpy_include])
 
-REQUIRES = ['setuptools', 'six', 'numpy>=1.6', 'astropy>=1.0', 'scipy', 'PyYaml']
+REQUIRES = ['setuptools', 'six>=1.7', 'numpy>=1.7', 'astropy>=1.0', 'scipy', 'PyYaml']
 
 from numina import __version__
 
@@ -75,6 +75,7 @@ setup(name='numina',
                    "Programming Language :: C",
                    "Programming Language :: Cython",
                    "Programming Language :: Python :: 2.7",
+                   "Programming Language :: Python :: 3.3",
                    "Programming Language :: Python :: 3.4",
                    "Programming Language :: Python :: Implementation :: CPython",
                    'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Numima seems to work with Python 3.3 (the version of Python 3 that can be installed in RHEL 7 via Software Collections, see https://www.softwarecollections.org/en/scls/rhscl/python33/), but it requires six >= 1.7