### PR TITLE
Create new subpackage 'numina.array.peaks', contains 1d peak finding routines

### DIFF
--- a/numina/array/peaks/findpeaks1D.py
+++ b/numina/array/peaks/findpeaks1D.py
@@ -1,23 +1,32 @@
-# Version 29 May 2015
-#------------------------------------------------------------------------------
+#
+# Copyright 2015 Universidad Complutense de Madrid
+#
+# This file is part of Numina
+#
+# Numina is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Numina is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Numina.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+"""Peak finding routines from wavecal"""
 
 from __future__ import division
-from __future__ import print_function
 
-import logging
-
-import six
-from six.moves import input
-
-import matplotlib.pyplot as plt
 import numpy as np
-
-_logger = logging.getLogger('numina.array.wavecal')
 
 #------------------------------------------------------------------------------
 
-def findPeaks_spectrum(sx, nwinwidth, data_threshold=0, 
-                       LDEBUG=False, LPLOT=False):
+def findPeaks_spectrum(sx, nwinwidth, data_threshold=0):
     """Find peaks in the 1d-numpy array sx.
 
     Note that nwinwidth must be an odd number. The function imposes that the
@@ -33,10 +42,6 @@ def findPeaks_spectrum(sx, nwinwidth, data_threshold=0,
         odd.
     data_threshold : float
         Minimum signal in the peak (optional).
-    LDEBUG : bool
-        If True the function prints out additional information.
-    LPLOT : bool
-        If True the function plots the spectrum and the peaks.
 
     Returns
     -------
@@ -49,12 +54,6 @@ def findPeaks_spectrum(sx, nwinwidth, data_threshold=0,
 
     sx_shape = sx.shape
     nmed = nwinwidth//2
-
-    _logger.debug('sx shape %s', sx_shape)
-    _logger.debug('nwinwidth %d',nwinwidth)
-    _logger.debug('nmed %d:',nmed)
-    _logger.debug('data_threshold %s',data_threshold)
-    _logger.debug('the first and last %d pixels will be ignored', nmed)
 
     ipeaks = []
 
@@ -70,7 +69,8 @@ def findPeaks_spectrum(sx, nwinwidth, data_threshold=0,
             j = 0
             loop = True
             while loop:
-                if sx[i-nmed+j] > sx[i-nmed+j+1]: lpeakgood = False
+                if sx[i-nmed+j] > sx[i-nmed+j+1]:
+                    lpeakgood = False
                 j += 1
                 loop = (j < nmed) and lpeakgood
 
@@ -91,23 +91,12 @@ def findPeaks_spectrum(sx, nwinwidth, data_threshold=0,
             i += 1
 
     npeaks = len(ipeaks)
-    _logger.debug('number of peaks found %i',npeaks)
-
-    if LPLOT:
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        ax.plot(list(six.moves.range(sx_shape[0])), sx, 'k-')
-        ax.set_xlabel('array index')
-        ax.set_ylabel('spectrum intensity')
-        ax.set_title('function findPeaks_spectrum')
-        plt.show(block=False)
-        input('press <RETURN> to continue...')
 
     return np.array(ipeaks, dtype=np.int)
 
 #------------------------------------------------------------------------------
 
-def refinePeaks_spectrum(sx, ipeaks, nwinwidth, method=2, LDEBUG=False):
+def refinePeaks_spectrum(sx, ipeaks, nwinwidth, method=2):
     """Refine the peak location previously found by findPeaks_spectrum()
 
     Parameters
@@ -122,8 +111,6 @@ def refinePeaks_spectrum(sx, ipeaks, nwinwidth, method=2, LDEBUG=False):
         Indicates which function will be employed to refine the peak location.
         method  = 1 -> fit to 2nd order polynomial
         method != 1 -> fit to gaussian
-    LDEBUG : bool
-        If True the function plots and prints out additional information.
 
     Returns
     -------
@@ -155,34 +142,6 @@ def refinePeaks_spectrum(sx, ipeaks, nwinwidth, method=2, LDEBUG=False):
             refined_peak = x0+jmax
 
         xfpeaks[iline] = refined_peak
-
-        if LDEBUG:
-            plt.figure()
-            xmin = x_fit.min()-1
-            xmax = x_fit.max()+1
-            ymin = 0
-            ymax = y_fit.max()*1.10
-            plt.axis([xmin,xmax,ymin,ymax])
-            plt.xlabel('channel (around initial integer peak)')
-            plt.ylabel('Normalized no. of counts')
-            plt.title('Fit to line at channel '+str(jmax))
-            plt.plot(x_fit,y_fit,"bo")
-            n_plot = 1000
-            x_plot = np.zeros(n_plot)
-            y_plot = np.zeros(n_plot)
-            for j in range(n_plot):
-                x_plot[j] = -nmed+float(j)/float(n_plot-1)*2*nmed
-                if method == 1:
-                    y_plot[j] = poly[2]+ \
-                                poly[1]*x_plot[j]+ \
-                                poly[0]*x_plot[j]*x_plot[j]
-                else:
-                    y_plot[j] = A*np.exp(-(x_plot[j]-x0)**2/(2*sigma**2))
-            plt.plot(x_plot,y_plot,color="red")
-            plt.show(block=False)
-            print('refined_peak:',refined_peak)
-            answer = input('Press <CR> to continue...')
-            plt.close()
 
     return xfpeaks
 

--- a/numina/array/peaks/peakdetection.py
+++ b/numina/array/peaks/peakdetection.py
@@ -43,7 +43,8 @@ def _vecS2(k, data):
     return ap
 
 
-# http://tcs-trddc.com/trddc_website/pdf/srl/palshikar_sapdts_2009.pdf
+# Extracted from here
+# http://www.researchgate.net/publication/228853276_Simple_Algorithms_for_Peak_Detection_in_Time-Series
 def _generic_peak_filtering(method, y, x=None, k=3, h=1.0, background=0.0,
                             xmin=None, xmax=None):
     '''Helper class for filtered peak finding.'''

--- a/numina/array/peaks/peakdetection.py
+++ b/numina/array/peaks/peakdetection.py
@@ -1,0 +1,214 @@
+#
+# Copyright 2014-2015 Universidad Complutense de Madrid
+#
+# This file is part of Numina
+#
+# Numina is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Numina is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Numina.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Peak finding routines backported from MEGARA"""
+
+import numpy as np
+from scipy.ndimage.filters import generic_filter
+
+
+def _vecS1(k, data):
+    '''max filter for peak detection.'''
+
+    def func(x):
+        return x[k] - 0.5 * (x[:k].max() + x[k+1:].max())
+
+    ap = generic_filter(data, func, size=2*k+1)
+    return ap
+
+
+def _vecS2(k, data):
+    '''min filter for peak detection.'''
+
+    def func(x):
+        return x[k] - 0.5 * (x[:k].mean() + x[k+1:].mean())
+
+    ap = generic_filter(data, func, size=2*k+1)
+    return ap
+
+
+# http://tcs-trddc.com/trddc_website/pdf/srl/palshikar_sapdts_2009.pdf
+def _generic_peak_filtering(method, y, x=None, k=3, h=1.0, background=0.0,
+                            xmin=None, xmax=None):
+    '''Helper class for filtered peak finding.'''
+
+    if x is None:
+        x = np.arange(len(y))
+
+    if xmin is None:
+        xmin = x[0]
+
+    if xmax is None:
+        xmax = x[-1]
+
+    candidates = []
+    # Fixme...
+
+    ap = method(k, y)
+    # mean and std of pos values
+    # ppos = ap[ap>0]
+    #
+    # This does not work, we need something local, not global
+    # mpos = appos.mean()
+    # spos = appos.std()
+
+    for idx, a in enumerate(ap):
+        if a > 0 and y[idx] > background and (xmin <= x[idx] <= xmax):
+            candidates.append(idx)
+
+    # Filter close elements
+    result = []
+    while len(candidates) > 1:
+
+        x0 = candidates[0]
+        for idx, xi in enumerate(candidates[1:], 1):
+            if abs(xi - x0) > k:
+                break
+
+        group = candidates[:idx]
+
+        remaining = candidates[idx:]
+        maxvalid = y[group].argmax()
+        finalid = group[maxvalid]
+        result.append((finalid, x[finalid], y[finalid]))
+
+        candidates = remaining
+
+    return np.array(result)
+
+
+def peak_detection_mean_window(y, x=None, k=3, h=1.0, background=0.0,
+                               xmin=None, xmax=None):
+    '''Detect peaks using a mean filter in a 2*k +1 window.
+
+    The filter value is the central point minus the mean of the 2*k
+    adjacent points.
+    '''
+    return _generic_peak_filtering(_vecS2, y, x=x, k=k, h=h,
+                                   background=background,
+                                   xmin=xmin, xmax=xmax)
+
+
+def peak_detection_max_window(y, x=None, k=3, h=1.0, background=0.0,
+                              xmin=None, xmax=None):
+    '''Detect peaks using a max filter in a 2*k +1 window.
+
+    The filter value is the central point minus the mean of the max
+    of the k-left and the max of the k-rigth neighbours.
+    '''
+    return _generic_peak_filtering(_vecS1, y, x=x, k=k, h=h,
+                                   background=background, xmin=xmin, xmax=xmax)
+
+
+def peakdet(v, delta, x=None, back=0.0):
+    '''Basic peak detection.'''
+
+    if x is None:
+        x = np.arange(len(v))
+
+    v = np.asarray(v)
+
+    if len(v) != len(x):
+        raise ValueError('Input vectors v and x must have same length')
+
+    if not np.isscalar(delta):
+        raise TypeError('Input argument delta must be a scalar')
+
+    if delta <= 0:
+        raise ValueError('Input argument delta must be positive')
+
+    maxtab = []
+    mintab = []
+
+    mn, mx = np.Inf, -np.Inf
+    mnpos, mxpos = np.NaN, np.NaN
+
+    lookformax = True
+
+    for i, this in enumerate(v):
+        if this > mx and this > back:
+            mx = this
+            mxpos = x[i]
+        if this < mn:
+            mn = this
+            mnpos = x[i]
+
+        if lookformax:
+            if this < mx - delta and this > back:
+                maxtab.append((mxpos, mx))
+                mn = this
+                mnpos = x[i]
+                lookformax = False
+        else:
+            if this > mn + delta:
+                mintab.append((mnpos, mn))
+                mx = this
+                mxpos = x[i]
+                lookformax = True
+
+    return np.array(maxtab), np.array(mintab)
+
+
+def peak_detection_basic(v, delta, x=None, back=0.0):
+    '''Basic peak detection.'''
+
+    if x is None:
+        x = np.arange(len(v))
+
+    v = np.asarray(v)
+
+    if len(v) != len(x):
+        raise ValueError('Input vectors v and x must have same length')
+
+    if not np.isscalar(delta):
+        raise TypeError('Input argument delta must be a scalar')
+
+    if delta <= 0:
+        raise ValueError('Input argument delta must be positive')
+
+    maxtab = []
+    mintab = []
+
+    mn, mx = np.Inf, -np.Inf
+    mnpos, mxpos = np.NaN, np.NaN
+
+    lookformax = True
+
+    for i, this in enumerate(v):
+        if this > mx and this > back:
+            mx = this
+            mxpos = x[i]
+        if this < mn:
+            mn = this
+            mnpos = x[i]
+
+        if lookformax:
+            if this < mx - delta and this > back:
+                maxtab.append((mxpos, mx))
+                mn = this
+                mnpos = x[i]
+                lookformax = False
+        else:
+            if this > mn + delta:
+                mintab.append((mnpos, mn))
+                mx = this
+                mxpos = x[i]
+                lookformax = True
+
+    return np.array(maxtab)


### PR DESCRIPTION
Peak-finding in 1D arrays is a common operation, so I have joined all the routines we have in a subpackage `numina.array.peaks`

* From wavecal, where the routines were not used (probably they were used in simulations) @nicocardiel 

* From megara.traces

The first step is to have all the routines together, then unify the interfaces and then see if we have to write a better algorithm

Fixes #55 