### PR TITLE
Remove LoadableDRP, load DRPS directly

### DIFF
--- a/numina/core/__init__.py
+++ b/numina/core/__init__.py
@@ -20,7 +20,7 @@
 from .recipes import BaseRecipe
 from .recipes import BaseRecipeAutoQC
 from .dataframe import DataFrame
-from .pipeline import Instrument, Pipeline, InstrumentConfiguration
+from .pipeline import InstrumentDRP, Pipeline, InstrumentConfiguration
 from .pipeline import ObservingMode
 from .objimport import import_object
 from .objimport import fully_qualified_name

--- a/numina/core/pipeline.py
+++ b/numina/core/pipeline.py
@@ -40,8 +40,8 @@ class InstrumentConfiguration(object):
         self.values = values
 
 
-class Instrument(object):
-    """Description of an Instrument."""
+class InstrumentDRP(object):
+    """Description of an Instrument Data Reduction Pipeline"""
     def __init__(self, name, configurations, modes, pipelines, products=None):
         self.name = name
         self.configurations = configurations

--- a/numina/core/pipeline.py
+++ b/numina/core/pipeline.py
@@ -98,10 +98,10 @@ class DrpSystem(object):
                 drp_loader = entry.load()
                 drpins = drp_loader()
 
-                if drpins:
+                if self.instrumentdrp_check(drpins, entry.name):
                     return drpins
                 else:
-                    warnings.warn('Module {0} does not contain a valid DRP'.format(drpins), RuntimeWarning)
+                    return None
         else:
             return None
 
@@ -113,15 +113,26 @@ class DrpSystem(object):
         for entry in pkg_resources.iter_entry_points(group=DrpSystem.ENTRY):
             drp_loader = entry.load()
             drpins = drp_loader()
-            if drpins:
+            if self.instrumentdrp_check(drpins, entry.name):
                 drps[drpins.name] = drpins
-            else:
-                warnings.warn('Module {0} does not contain a valid DRP'.format(drpins), RuntimeWarning)
 
         # Update cache
         self._drp_cache = drps
 
         return drps
+
+    def instrumentdrp_check(self, drpins, entryname):
+        if isinstance(drpins, InstrumentDRP):
+            if drpins.name == entryname:
+                return True
+            else:
+                msg = 'Entry name {} and DRP name {} differ'.format(entryname, drpins.name)
+                warnings.warn(msg, RuntimeWarning)
+                return False
+        else:
+            msg = 'Object {} does not contain a valid DRP'.format(drpins)
+            warnings.warn(msg, RuntimeWarning)
+            return False
 
 
 def init_store_backends(backend='default'):

--- a/numina/core/pipeline.py
+++ b/numina/core/pipeline.py
@@ -68,12 +68,6 @@ class ObservingMode(object):
         self.tagger = None
 
 
-class LoadableDRP(object):
-    """Container for the loaded DRP."""
-    def __init__(self, instruments):
-        self.instruments = instruments
-
-
 class DrpSystem(object):
     """Load DRPs from the system."""
 
@@ -102,32 +96,32 @@ class DrpSystem(object):
         for entry in pkg_resources.iter_entry_points(group=DrpSystem.ENTRY):
             if entry.name == name:
                 drp_loader = entry.load()
-                mod = drp_loader()
+                drpins = drp_loader()
 
-                if mod:
-                    return mod.instruments[name]
+                if drpins:
+                    return drpins
                 else:
-                    warnings.warn('Module {0} does not contain a valid DRP'.format(mod), RuntimeWarning)
+                    warnings.warn('Module {0} does not contain a valid DRP'.format(drpins), RuntimeWarning)
         else:
             return None
 
     def query_all(self):
         """Return all available DRPs in 'numina.pipeline' entry_point."""
 
-        drp = {}
+        drps = {}
 
         for entry in pkg_resources.iter_entry_points(group=DrpSystem.ENTRY):
             drp_loader = entry.load()
-            mod = drp_loader()
-            if mod:
-                drp.update(mod.instruments)
+            drpins = drp_loader()
+            if drpins:
+                drps[drpins.name] = drpins
             else:
-                warnings.warn('Module {0} does not contain a valid DRP'.format(mod), RuntimeWarning)
+                warnings.warn('Module {0} does not contain a valid DRP'.format(drpins), RuntimeWarning)
 
         # Update cache
-        self._drp_cache = drp
+        self._drp_cache = drps
 
-        return drp
+        return drps
 
 
 def init_store_backends(backend='default'):

--- a/numina/core/pipeline.py
+++ b/numina/core/pipeline.py
@@ -126,11 +126,11 @@ class DrpSystem(object):
             if drpins.name == entryname:
                 return True
             else:
-                msg = 'Entry name {} and DRP name {} differ'.format(entryname, drpins.name)
+                msg = 'Entry name "{}" and DRP name "{}" differ'.format(entryname, drpins.name)
                 warnings.warn(msg, RuntimeWarning)
                 return False
         else:
-            msg = 'Object {} does not contain a valid DRP'.format(drpins)
+            msg = 'Object {0!r} does not contain a valid DRP'.format(drpins)
             warnings.warn(msg, RuntimeWarning)
             return False
 

--- a/numina/core/pipelineload.py
+++ b/numina/core/pipelineload.py
@@ -27,7 +27,6 @@ import yaml
 from .objimport import import_object
 from .pipeline import ObservingMode
 from .pipeline import Pipeline
-from .pipeline import LoadableDRP
 from .pipeline import Instrument
 from .pipeline import InstrumentConfiguration
 
@@ -56,12 +55,9 @@ def drp_load(package, resource):
 
 def drp_load_data(data):
     """Load the DRPS from data."""
-    ins_all = {}
-    for yld in yaml.load_all(data):
-        ins = load_instrument(yld)
-        ins_all[ins.name] = ins
-
-    return LoadableDRP(ins_all)
+    drpdict = yaml.load(data)
+    ins = load_instrument(drpdict)
+    return ins
 
 
 def load_modes(node):

--- a/numina/core/pipelineload.py
+++ b/numina/core/pipelineload.py
@@ -27,7 +27,7 @@ import yaml
 from .objimport import import_object
 from .pipeline import ObservingMode
 from .pipeline import Pipeline
-from .pipeline import Instrument
+from .pipeline import InstrumentDRP
 from .pipeline import InstrumentConfiguration
 
 
@@ -152,7 +152,7 @@ def load_instrument(node):
     trans['modes'] = load_modes(mode_node)
     trans['configurations'] = load_confs(conf_node)
     trans['products'] = prod_node
-    return Instrument(**trans)
+    return InstrumentDRP(**trans)
 
 
 def print_i(ins):

--- a/numina/core/test/test_drpload.py
+++ b/numina/core/test/test_drpload.py
@@ -79,7 +79,7 @@ def test_drpsys_faulty_instrument(drpmocker, recwarn):
     """Test that only one DRP is returned."""
 
     def faulty_loader():
-        pass
+        return 3
 
     drpmocker.add_drp('FAULTY', faulty_loader)
 
@@ -93,12 +93,12 @@ def test_drpsys_faulty_instrument(drpmocker, recwarn):
 
     w = recwarn.pop(RuntimeWarning)
 
-    expected = 'Object None does not contain a valid DRP'
+    expected = 'Object 3 does not contain a valid DRP'
     assert str(w.message) == expected
 
 
 @pytest.mark.parametrize("entryn",
-                         [('other',), ('fake1',)],
+                         ['other', 'fake1'],
                          ids=['different', 'lowercase']
                          )
 def test_drpsys_not_valid_name(drpmocker, recwarn, entryn):
@@ -106,7 +106,7 @@ def test_drpsys_not_valid_name(drpmocker, recwarn, entryn):
     # I like better the "with pytest.warn" mechanism
     # but I don't have yet pytest 2.8
 
-    drpmocker.add_drp(entryn, drpdata1)
+    drpmocker.add_drp(entryn, drpdata2)
 
     drpsys = DrpSystem()
 
@@ -118,7 +118,7 @@ def test_drpsys_not_valid_name(drpmocker, recwarn, entryn):
 
     w = recwarn.pop(RuntimeWarning)
 
-    expected = 'Entry name "{}" and DRP name "{}" differ'.format(entryn, 'FAKE1')
+    expected = 'Entry name "{}" and DRP name "{}" differ'.format(entryn, 'FAKE2')
     assert str(w.message) == expected
 
 
@@ -201,7 +201,7 @@ def test_ins_check_not_valid_data(recwarn):
 
     drpsys = DrpSystem()
 
-    result = drpsys.instrumentdrp_check(None, 'name')
+    result = drpsys.instrumentdrp_check("astring", 'noname')
 
     assert result is False
 
@@ -209,11 +209,11 @@ def test_ins_check_not_valid_data(recwarn):
 
     w = recwarn.pop(RuntimeWarning)
 
-    assert str(w.message) == 'Object None does not contain a valid DRP'
+    assert str(w.message) == "Object 'astring' does not contain a valid DRP"
 
 
 @pytest.mark.parametrize("entryn",
-                         [('other',), ('fake1',)],
+                         ['other', 'fake1'],
                          ids=['different', 'lowercase']
                          )
 def test_ins_check_not_valid_name(recwarn, entryn):

--- a/numina/core/test/test_pipelines.py
+++ b/numina/core/test/test_pipelines.py
@@ -2,11 +2,11 @@
 import pkg_resources
 
 from numina.core.pipeline import DrpSystem
-from numina.core.pipeline import Instrument, Pipeline
+from numina.core.pipeline import InstrumentDRP, Pipeline
 
 
 def assert_valid_instrument(instrument):
-    assert isinstance(instrument, Instrument)
+    assert isinstance(instrument, InstrumentDRP)
 
     pipes = instrument.pipelines
     assert 'default' in pipes
@@ -23,7 +23,7 @@ def test_fake_pipeline(monkeypatch):
             confs = None
             modes = None
             pipelines = {'default': Pipeline('default', {}, 1)}
-            fake = Instrument('FAKE', confs, modes, pipelines)
+            fake = InstrumentDRP('FAKE', confs, modes, pipelines)
             return fake
 
         ep = pkg_resources.EntryPoint('fake', 'fake.loader')

--- a/numina/core/test/test_pipelines.py
+++ b/numina/core/test/test_pipelines.py
@@ -1,8 +1,8 @@
 
-from numina.core.pipeline import DrpSystem
-from numina.core.pipeline import LoadableDRP, Instrument, Pipeline
-from numina.core.pipelineload import drp_load_data
 import pkg_resources
+
+from numina.core.pipeline import DrpSystem
+from numina.core.pipeline import Instrument, Pipeline
 
 
 def assert_valid_instrument(instrument):
@@ -24,7 +24,7 @@ def test_fake_pipeline(monkeypatch):
             modes = None
             pipelines = {'default': Pipeline('default', {}, 1)}
             fake = Instrument('FAKE', confs, modes, pipelines)
-            return LoadableDRP({'fake': fake})
+            return fake
 
         ep = pkg_resources.EntryPoint('fake', 'fake.loader')
         monkeypatch.setattr(ep, 'load', lambda: fake_loader)

--- a/numina/user/tests/test_cli_show_ins.py
+++ b/numina/user/tests/test_cli_show_ins.py
@@ -6,7 +6,7 @@ from ..cli import main
 
 
 drpdata = """
-    name: FAKE
+    name: FAKE1
     configurations:
         default: {}
     modes:
@@ -55,10 +55,10 @@ drpdata2 = """
 
 
 def test_show_instrument(capsys, drpmocker):
-    """Test that one instrumenst is shown"""
-    drpmocker.add_drp('fake', drpdata)
+    """Test that one instrument is shown"""
+    drpmocker.add_drp('FAKE1', drpdata)
 
-    expected = ("Instrument: FAKE\n"
+    expected = ("Instrument: FAKE1\n"
                 " has configuration 'default'\n"
                 " has pipeline 'default', version 1\n"
                 )
@@ -73,13 +73,13 @@ def test_show_2_instruments(capsys, drpmocker):
     """Test that two instruments are shown"""
 
     # FIXME: probably instruments can be output in any order
-    drpmocker.add_drp('fake', drpdata)
-    drpmocker.add_drp('fake2', drpdata2)
+    drpmocker.add_drp('FAKE1', drpdata)
+    drpmocker.add_drp('FAKE2', drpdata2)
 
     expected = ["Instrument: FAKE2",
                 " has configuration 'default'",
                 " has pipeline 'default', version 1",
-                "Instrument: FAKE",
+                "Instrument: FAKE1",
                 " has configuration 'default'",
                 " has pipeline 'default', version 1",
                 ""


### PR DESCRIPTION
Instead of loading a LoadableDRP object, that is a dictionary, where each value is a Instrument, load directly a Instrument (now InstrumentDRP).