### PR TITLE
Uses a magic method instad of dispatching (mostly) for dump results

### DIFF
--- a/numina/core/products.py
+++ b/numina/core/products.py
@@ -31,6 +31,8 @@ from .dataframe import DataFrame
 from .types import DataType
 from numina.frame.schema import Schema
 from numina.exceptions import ValidationError
+from numina.store.default import dump_numpy_array
+from numina.store.default import dump_dataframe
 
 
 class DataProductTag(object):
@@ -88,6 +90,9 @@ class DataFrameType(DataType):
     def validate_hdulist(self, hdulist):
         pass
 
+    def __numina_dump__(self, obj, where):
+        return dump_dataframe(obj, where)
+
 
 class ArrayType(DataType):
     def __init__(self, default=None):
@@ -99,6 +104,9 @@ class ArrayType(DataType):
     def convert_to_array(self, obj):
         result = numpy.array(obj)
         return result
+
+    def __numina_dump__(self, obj, where):
+        return dump_numpy_array(obj, where)
 
 
 class ArrayNType(ArrayType):

--- a/numina/core/recipeinout.py
+++ b/numina/core/recipeinout.py
@@ -25,7 +25,8 @@ from six import with_metaclass
 import yaml
 
 from .metaclass import RecipeInputType, RecipeResultType
-from numina.store.dump import dump
+import numina.store.dump
+
 
 class RecipeInOut(object):
 
@@ -106,7 +107,7 @@ class ErrorRecipeResult(BaseRecipeResult):
         fmt = "%s(errortype=%r, message='%s')"
         return fmt % (sclass, self.errortype, self.message)
 
-    def store(self, where):
+    def store_to(self, where):
         with open(where.result, 'w+') as fd:
             yaml.dump(where.result, fd)
 
@@ -122,13 +123,13 @@ class RecipeResult(with_metaclass(RecipeResultType, RecipeInOut, BaseRecipeResul
             full.append('%s=%r' % (key, val))
         return '%s(%s)' % (sclass, ', '.join(full))
 
-    def store(self, where):
+    def store_to(self, where):
 
         saveres = {}
-        for key, pc in self.stored().items():
+        for key, prod in self.stored().items():
             val = getattr(self, key)
-            where.destination = pc.dest
-            saveres[key] = dump(pc.type, val, where)
+            where.destination = prod.dest
+            saveres[key] = numina.store.dump.dump(pc.type, val, where)
 
         with open(where.result, 'w+') as fd:
             yaml.dump(saveres, fd)

--- a/numina/core/types.py
+++ b/numina/core/types.py
@@ -38,6 +38,9 @@ class DataType(object):
             raise ValidationError(obj, self.python_type)
         return True
 
+    def __numina_dump__(self, obj, where):
+        return obj
+
     def __repr__(self):
         sclass = type(self).__name__
         return "%s()" % (sclass, )

--- a/numina/store/__init__.py
+++ b/numina/store/__init__.py
@@ -1,3 +1,3 @@
-
+from .dump import dump
 from .load import load
 

--- a/numina/store/__init__.py
+++ b/numina/store/__init__.py
@@ -1,4 +1,3 @@
 
-from .dump import dump
 from .load import load
 

--- a/numina/store/default.py
+++ b/numina/store/default.py
@@ -17,66 +17,12 @@
 # along with Numina.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-"""Register basic types with dump."""
+"""Two basic functions to store frames and arrays"""
 
-from __future__ import print_function
 
 import warnings
 
 import numpy
-import yaml
-
-from numina.core import RecipeResult
-from numina.core import ErrorRecipeResult
-from numina.core import DataFrameType, DataProductType
-from numina.core.types import PlainPythonType
-from numina.core.products import ArrayType
-from numina.core import DataFrame
-
-from .dump import dump
-
-
-@dump.register(ErrorRecipeResult)
-def _(tag, obj, where):
-    with open(where.result, 'w+') as fd:
-        yaml.dump(where.result, fd)
-
-    return where.result
-
-
-@dump.register(RecipeResult)
-def _(tag, obj, where):
-
-    saveres = {}
-    for key, pc in obj.stored().items():
-        val = getattr(obj, key)
-        where.destination = pc.dest
-        saveres[key] = dump(pc.type, val, where)
-
-    with open(where.result, 'w+') as fd:
-        yaml.dump(saveres, fd)
-
-    return where.result
-
-
-@dump.register(DataProductType)
-def _(tag, obj, where):
-    return obj
-
-
-@dump.register(PlainPythonType)
-def _(tag, obj, where):    
-    return obj
-
-
-@dump.register(ArrayType)
-def _(tag, obj, where):
-    return dump_numpy_array(obj, where)
-
-
-@dump.register(DataFrameType)
-def _(tag, obj, where):
-    return dump_dataframe(obj, where)
 
 
 def dump_dataframe(obj, where):
@@ -107,19 +53,6 @@ def dump_numpy_array(obj, where):
     return filename
 
 
-dump.register(numpy.ndarray, dump_numpy_array)
-
-dump.register(DataFrame, dump_dataframe)
-
-
-@dump.register(list)
-def _(tag, obj, where):
-    return [dump(tag, o, where) for o in obj]
-
-
-# FIXME: this is very convoluted
-from .defaultl import load_cli_storage as other
-
-
+# FIXME: remove this function together with init_dump_backends
 def load_cli_storage():
-    return other()
+    pass

--- a/numina/store/dump.py
+++ b/numina/store/dump.py
@@ -1,4 +1,22 @@
-from __future__ import print_function
+#
+# Copyright 2010-2015 Universidad Complutense de Madrid
+#
+# This file is part of Numina
+#
+# Numina is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Numina is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Numina.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 
 
 try:
@@ -6,8 +24,29 @@ try:
 except ImportError:
     from singledispatch import singledispatch
 
+import numpy
+
+from numina.core.dataframe import DataFrame
+from .default import dump_dataframe, dump_numpy_array
 
 @singledispatch
 def dump(tag, obj, where):
-    return obj
 
+    if hasattr(tag, '__numina_dump__'):
+        return tag.__numina_dump__(obj, where)
+    else:
+        return obj
+
+# It's not clear if I need to register these three
+# functions
+
+
+@dump.register(list)
+def _(tag, obj, where):
+    return [dump(tag, o, where) for o in obj]
+
+
+dump.register(numpy.ndarray, dump_numpy_array)
+
+
+dump.register(DataFrame, dump_dataframe)

--- a/numina/user/helpers.py
+++ b/numina/user/helpers.py
@@ -29,7 +29,6 @@ import shutil
 import yaml
 
 from numina.core.pipeline import init_store_backends
-from numina.store import dump
 from numina.core.products import DataFrameType
 
 _logger = logging.getLogger("numina")
@@ -56,9 +55,12 @@ class ProcessingTask(object):
 
     def store(self, where):
 
-        sresult = self.result.store(where)
+        # save to disk the RecipeResult part
+        # and return the file used to save it
+        sresult = self.result.store_to(where)
         self.result = sresult
 
+        # save to disk the rest
         with open(where.task, 'w+') as fd:
             yaml.dump(self.__dict__, fd)
         return where.task

--- a/numina/user/helpers.py
+++ b/numina/user/helpers.py
@@ -56,10 +56,9 @@ class ProcessingTask(object):
 
     def store(self, where):
 
-        sresult = dump(self.result,
-                       self.result,
-                       where)
+        sresult = self.result.store(where)
         self.result = sresult
+
         with open(where.task, 'w+') as fd:
             yaml.dump(self.__dict__, fd)
         return where.task

--- a/numina/user/helpers.py
+++ b/numina/user/helpers.py
@@ -17,7 +17,7 @@
 # along with Numina.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-'''User command line interface of Numina.'''
+"""User command line interface of Numina."""
 
 from __future__ import print_function
 
@@ -26,8 +26,11 @@ import os
 import errno
 import shutil
 
-from numina.core.products import DataFrameType
+import yaml
 
+from numina.core.pipeline import init_store_backends
+from numina.store import dump
+from numina.core.products import DataFrameType
 
 _logger = logging.getLogger("numina")
 
@@ -37,6 +40,7 @@ class ProcessingTask(object):
 
         self.observation = {}
         self.runinfo = {}
+        self.result = None
 
         if obsres:
             self.observation['mode'] = obsres.mode
@@ -49,6 +53,16 @@ class ProcessingTask(object):
 
         if insconf:
             self.observation['instrument_configuration'] = insconf
+
+    def store(self, where):
+
+        sresult = dump(self.result,
+                       self.result,
+                       where)
+        self.result = sresult
+        with open(where.task, 'w+') as fd:
+            yaml.dump(self.__dict__, fd)
+        return where.task
 
 
 class WorkEnvironment(object):
@@ -140,10 +154,6 @@ class DiskStorage(object):
         return fname
 
 
-from numina.core.pipeline import init_store_backends
-from numina.store import dump
-
-
 class DiskStorageDefault(DiskStorage):
     def __init__(self, resultsdir):
         super(DiskStorageDefault, self).__init__()
@@ -152,9 +162,8 @@ class DiskStorageDefault(DiskStorage):
         self.resultsdir = resultsdir
         init_store_backends()
 
-
     def store(self, completed_task):
-        '''Store the values of the completed task'''
+        """Store the values of the completed task."""
 
         try:
             csd = os.getcwd()
@@ -162,7 +171,7 @@ class DiskStorageDefault(DiskStorage):
             os.chdir(self.resultsdir)
 
             _logger.info('storing result')
-            dump(completed_task, completed_task, self)
+            completed_task.store(self)
 
         finally:
             _logger.debug('cwd to original path: %r', csd)


### PR DESCRIPTION
Use magic method `__numina_dump__` instead if dispatching for data products. The function `numina.store.dump` still uses `simpledispatch`, but for subclasses of `DataType` it is not necessary.

Dispatch is still needed for objects of a class that is not a subclass of DataType