### PR TITLE
Fix remote test failling due to matplotlib

### DIFF
--- a/numina/array/wavecal/arccalibration.py
+++ b/numina/array/wavecal/arccalibration.py
@@ -22,12 +22,6 @@
 from __future__ import division
 from __future__ import print_function
 
-try:
-    import matplotlib.pyplot as plt
-
-    HAVE_PLOTS = True
-except ImportError:
-    HAVE_PLOTS = False
 import numpy as np
 from numpy.polynomial import polynomial
 import itertools

--- a/numina/array/wavecal/slitlet.py
+++ b/numina/array/wavecal/slitlet.py
@@ -5,8 +5,7 @@ import numpy as np
 from numpy.polynomial import polynomial
 
 try:
-    import matplotlib.pyplot as plt
-
+    import matplotlib
     HAVE_PLOTS = True
 except ImportError:
     HAVE_PLOTS = False
@@ -156,6 +155,9 @@ class Slitlet(object):
             fluxsp /= deltaysp
 
         if LDEBUG and HAVE_PLOTS:
+            # Required to delay the backend initialization (issue #102)
+            import matplotlib.pyplot as plt
+
             # plot image with bounding box, boundaries, etc.
             naxis2, naxis1 = image2d.shape
             fig = plt.figure()


### PR DESCRIPTION
In some cases  (#102), tests fail due to

```
import matplotlib.pyplot as plt
```
trying to load the default backend in a remote host. This PR puts this import near the code that uses it.
