### PR TITLE
Define _datatype_{load, dump}, instead of __numina_{load,dump}

### DIFF
--- a/numina/core/products.py
+++ b/numina/core/products.py
@@ -89,10 +89,10 @@ class DataFrameType(DataType):
     def validate_hdulist(self, hdulist):
         pass
 
-    def __numina_dump__(self, obj, where):
+    def _datatype_dump(self, obj, where):
         return dump_dataframe(obj, where)
 
-    def __numina_load__(self, obj):
+    def _datatype_load(self, obj):
         if obj is None:
             return None
         else:
@@ -110,10 +110,10 @@ class ArrayType(DataType):
         result = numpy.array(obj)
         return result
 
-    def __numina_dump__(self, obj, where):
+    def _datatype_dump(self, obj, where):
         return dump_numpy_array(obj, where)
 
-    def __numina_load__(self, obj):
+    def _datatype_load(self, obj):
         if isinstance(obj, six.string_types):
             # if is a string, it may be a pathname, try to load it
 

--- a/numina/core/types.py
+++ b/numina/core/types.py
@@ -38,7 +38,7 @@ class DataType(object):
             raise ValidationError(obj, self.python_type)
         return True
 
-    def __numina_dump__(self, obj, where):
+    def _datatype_dump(self, obj, where):
         return obj
 
     def __repr__(self):

--- a/numina/store/dump.py
+++ b/numina/store/dump.py
@@ -17,7 +17,7 @@
 # along with Numina.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-
+import warnings
 
 try:
     from functools import singledispatch
@@ -33,9 +33,14 @@ from numina.core.products import dump_dataframe,dump_numpy_array
 def dump(tag, obj, where):
 
     if hasattr(tag, '__numina_dump__'):
+        msg = "Usage of '__numina_dump__' is deprecated, use '_datatype_dump' instead"
+        warnings.warn(msg, DeprecationWarning)
         return tag.__numina_dump__(obj, where)
-    else:
-        return obj
+
+    if hasattr(tag, '_datatype_dump'):
+        return tag._datatype_dump(obj, where)
+
+    return obj
 
 # It's not clear if I need to register these three
 # functions

--- a/numina/store/load.py
+++ b/numina/store/load.py
@@ -1,5 +1,23 @@
-from __future__ import print_function
+#
+# Copyright 2010-2015 Universidad Complutense de Madrid
+#
+# This file is part of Numina
+#
+# Numina is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Numina is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Numina.  If not, see <http://www.gnu.org/licenses/>.
+#
 
+import warnings
 
 try:
     from functools import singledispatch
@@ -11,7 +29,12 @@ except ImportError:
 def load(tag, obj):
 
     if hasattr(tag, '__numina_load__'):
+        msg = "Usage of '__numina_load__' is deprecated, use '_datatype_load' instead"
+        warnings.warn(msg, DeprecationWarning)
         return tag.__numina_load__(obj)
+
+    if hasattr(tag, '_datatype_load'):
+        return tag._datatype_load(obj)
 
     return obj
 

--- a/numina/store/tests/test_dump.py
+++ b/numina/store/tests/test_dump.py
@@ -6,6 +6,19 @@ import pytest
 
 from ..dump import dump
 
+
+def test_dump_base():
+
+    class A(object):
+        pass
+
+    tag = A()
+    obj = 0
+    where = ""
+
+    assert obj == dump(tag, obj, where)
+
+
 def test_dump_method():
 
     class A(object):

--- a/numina/store/tests/test_dump.py
+++ b/numina/store/tests/test_dump.py
@@ -1,0 +1,61 @@
+
+import sys
+import warnings
+
+import pytest
+
+from ..dump import dump
+
+def test_dump_method():
+
+    class A(object):
+
+        def _datatype_dump(self, obj, where):
+            return obj + 1
+
+    tag = A()
+    obj = 1
+    where = ""
+
+    assert obj + 1 == dump(tag, obj, where)
+
+
+def test_dump_method_deprecated():
+
+    class B(object):
+
+        def __numina_dump__(self, obj, where):
+            return obj + 2
+
+    tag = B()
+    obj = 1
+    where = ""
+
+    assert obj + 2 == dump(tag, obj, where)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 4),
+                    reason="https://github.com/pytest-dev/pytest/issues/840")
+def test_dump_method_deprecated_warning(recwarn):
+    warnings.simplefilter('always')
+    test_dump_method_deprecated()
+
+    assert recwarn.pop(DeprecationWarning)
+
+
+def test_dump_method_register():
+
+    class C(object):
+        pass
+
+    def numina_dump_func(tag, obj, where):
+        return obj + 3
+
+    dump.register(C, numina_dump_func)
+
+    tag = C()
+    obj = 1
+    where = ""
+
+    assert obj + 3 == dump(tag, obj, where)
+

--- a/numina/store/tests/test_load.py
+++ b/numina/store/tests/test_load.py
@@ -6,6 +6,18 @@ import pytest
 
 from ..load import load
 
+
+def test_load_base():
+
+    class A(object):
+        pass
+
+    tag = A()
+    obj = 0
+
+    assert obj == load(tag, obj)
+
+
 def test_load_method():
 
     class A(object):

--- a/numina/store/tests/test_load.py
+++ b/numina/store/tests/test_load.py
@@ -1,0 +1,58 @@
+
+import sys
+import warnings
+
+import pytest
+
+from ..load import load
+
+def test_load_method():
+
+    class A(object):
+
+        def _datatype_load(self, obj):
+            return obj + 1
+
+    tag = A()
+    obj = 1
+
+    assert obj + 1 == load(tag, obj)
+
+
+def test_load_method_deprecated():
+
+    class B(object):
+
+        def __numina_load__(self, obj):
+            return obj + 2
+
+    tag = B()
+    obj = 1
+
+    assert obj + 2 == load(tag, obj)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 4),
+                    reason="https://github.com/pytest-dev/pytest/issues/840")
+def test_dump_method_deprecated_warning(recwarn):
+    warnings.simplefilter('always')
+    test_load_method_deprecated()
+
+    assert recwarn.pop(DeprecationWarning)
+
+
+def test_load_method_register():
+
+    class C(object):
+        pass
+
+    def numina_load_func(tag, obj):
+        return obj + 3
+
+    load.register(C, numina_load_func)
+
+    tag = C()
+    obj = 1
+
+    assert obj + 3 == load(tag, obj)
+


### PR DESCRIPTION
Data type classes have a _datatype_{load, dump}, instead of __numina_{load,dump}

Fixes #109 

* Usage of  __numina_{load,dump} is still supported, but deprecated
